### PR TITLE
Cria arquivos kubernetes e edita documentação

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ build/
 
 ### db ###
 data/
+
+### secrets ###
+/kubernetes/mysql/mysql-secret.yaml

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ impactando os negócios de forma negativa.
 
 Dessa forma, o objetivo do projeto do curso é desenvolver um sistema de autoatendimento de fast food, que é composto por uma série de dispositivos e
 interfaces que permitem aos clientes selecionar e fazer pedidos sem precisar interagir com um
-atendente, com funcionalidades de pagamento, criação, acompanhamentode e entrega do pedido.
+atendente, com funcionalidades de pagamento, criação, acompanhamento e entrega do pedido.
 
 # Descrição
 Projeto desenvolvido em Java 20 e Spring Framework, com banco de dados MySQL, Docker para
@@ -73,6 +73,54 @@ com webhook para captação desses pagamentos.
 # Execução
 1. Executar `git clone git@github.com:matheus-mr94/postech-soat1.git`
 2. Rodar `docker-compose up --build` na raiz do projeto
+
+# Executando com Kubernets
+
+1 - Crie um arquivo mysql-secret.yaml dentro do diretório kubernetes/mysql.
+
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysql-secret
+data:
+  MYSQL_ROOT_PASSWORD: {CHAVE}
+  MYSQL-DATABASE: {CHAVE}
+  MYSQL-USER: {CHAVE}
+  MYSQL-PASSWORD: {CHAVE}
+```
+
+Certifique-se de codificar as chaves em Base64 antes de inseri-las no arquivo.
+
+Em seguida, execute o comando a seguir para criar o objeto:
+
+```
+kubectl apply -f kubernetes/mysql/mysql-secret.yaml
+```
+
+2 - Configurar banco de dados
+
+Agora, configure os recursos do banco de dados. Primeiro, aplique o arquivo de solicitação de volume persistente:
+
+```
+kubectl apply -f kubernetes/mysql/mysql-persistentvolumeclaim.yaml
+```
+
+Em seguida, crie o deployment e o serviço MySQL:
+
+```
+kubectl apply -f kubernetes/mysql/mysql-deployment.yaml
+kubectl apply -f kubernetes/mysql/mysql-service.yaml
+```
+
+3 - Configurar a API
+
+Aplique o deployment e o serviço da aplicação:
+
+```
+kubectl apply -f kubernetes/app/app-deployment.yaml
+kubectl apply -f kubernetes/app/app-service.yaml
+```
 
 # Funcionalidades
 ## Cadastro do Cliente

--- a/kubernetes/app/app-deployment.yaml
+++ b/kubernetes/app/app-deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-deployment
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+        - name: postech-soat1-app
+          image: monicahillman/postech-soat1-app:latest
+          ports:
+            - containerPort: 8080

--- a/kubernetes/app/app-service.yaml
+++ b/kubernetes/app/app-service.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: app-service
+spec:
+  type: LoadBalancer
+  ports:
+    - name: "8080"
+      port: 8080

--- a/kubernetes/mysql/mysql-deployment.yaml
+++ b/kubernetes/mysql/mysql-deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mysql
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      containers:
+        - name: mysql-container
+          image: mysql:latest
+          env:
+                  - name: MYSQL_USER
+                    valueFrom:
+                      secretKeyRef:
+                        name: mysql-secret
+                        key: MYSQL_USER
+                  - name: MYSQL_PASSWORD
+                    valueFrom:
+                      secretKeyRef:
+                        name: mysql-secret
+                        key: MYSQL_PASSWORD
+                  - name: MYSQL_ROOT_PASSWORD
+                    valueFrom:
+                      secretKeyRef:
+                        name: mysql-secret
+                        key: MYSQL_ROOT_PASSWORD
+          ports:
+            - containerPort: 3306
+      restartPolicy: Always
+

--- a/kubernetes/mysql/mysql-persistentvolumeclaim.yaml
+++ b/kubernetes/mysql/mysql-persistentvolumeclaim.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql-persistencevolumeclaim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi

--- a/kubernetes/mysql/mysql-service.yaml
+++ b/kubernetes/mysql/mysql-service.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql-service
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 3306
+      targetPort: 3306


### PR DESCRIPTION
# Construir arquivos de configuração do Kubernetes:

## Deployment da aplicação com ao menos 2 Pods:

* Foi construído o arquivo app-deployment.yaml com as configs para o deploy da API. 

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: app-deployment  # Nome do Deployment
spec:
  replicas: 2  # Número de réplicas do pod
  selector:
    matchLabels:
      app: app  # Seleciona pods com a label "app: app"
  template:  # Template do pod que será implantado
    metadata:
      labels:
        app: app  # Label "app: app" para o pod
    spec:
      containers:
        - name: postech-soat1-app  # Nome do container
          image: monicahillman/postech-soat1-app:latest  # Coloquei a imagem no DockerHub pra conseguir acessar nesse arquivo
          ports:
            - containerPort: 8080  # Porta que o container está ouvindo
```

OBS: [Segundo o prof. Luiz Zenha os 2 pods seriam para replicas da sua aplicação](https://discord.com/channels/1065992165232214066/1134870064122830999/1146230036987400192), por isso apliquei duas réplicas.

* Também construí um deployment para o banco de dados:

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: mysql-deployment  # Nome do Deployment para o MySQL
spec:
  replicas: 1  # Uma única réplica do pod
  selector:
    matchLabels:
      app: mysql  # Seleciona pods com a label "app: mysql"
  template:  # Template do pod que será implantado
    metadata:
      labels:
        app: mysql  # Label "app: mysql" para o pod
    spec:
      containers:
        - name: mysql-container  # Nome do container MySQL
          image: mysql:latest  # Imagem do container MySQL
          env:  # Variáveis de ambiente do container
            - name: MYSQL_USER
              valueFrom:
                secretKeyRef:
                  name: mysql-secret  # Nome do segredo para a variável MYSQL_USER
                  key: MYSQL_USER  # Chave dentro do segredo para o valor da variável
            - name: MYSQL_PASSWORD
              valueFrom:
                secretKeyRef:
                  name: mysql-secret  # Nome do segredo para a variável MYSQL_PASSWORD
                  key: MYSQL_PASSWORD  # Chave dentro do segredo para o valor da variável
            - name: MYSQL_ROOT_PASSWORD
              valueFrom:
                secretKeyRef:
                  name: mysql-secret  # Nome do segredo para a variável MYSQL_ROOT_PASSWORD
                  key: MYSQL_ROOT_PASSWORD  # Chave dentro do segredo para o valor da variável
          ports:
            - containerPort: 3306  # Porta que o container MySQL está ouvindo
      restartPolicy: Always  # Política de reinício: sempre reiniciar o pod em caso de falha
```

## Service para Load Balancer do tipo NLB ou ALB.

* Construído um serviço para a API:

```
apiVersion: v1
kind: Service
metadata:
  name: app-service  # Nome do Service
spec:
  type: LoadBalancer  # Tipo de Service: LoadBalancer
  ports:
    - name: "8080"  # Nome da porta do Service
      port: 8080  # Número da porta do Service
```

* Construído um serviço para o Banco de Dados:

```
apiVersion: v1
kind: Service
metadata:
  name: mysql-service  # Nome do Service
spec:
  type: LoadBalancer  # Tipo de Service: LoadBalancer
  ports:
    - port: 3306  # Porta do Service
      targetPort: 3306  # Porta alvo (a porta que os pods estão ouvindo)
```

## Configuração de acesso aos serviços da AWS parametrizados via secrets.

[Segundo a prof. Nathália Santos: são secrets do próprio k8 e não da aws.](https://discord.com/channels/1065992165232214066/1140610208289280066/1141840529915646002). Aqui configurei as variáveis de ambiente do banco de dados via secrets construído no arquivo kubernetes/mysql-secrets.yaml.

```
apiVersion: v1
kind: Secret
metadata:
  name: mysql-secret
data:
  MYSQL_ROOT_PASSWORD: {CHAVE}
  MYSQL-DATABASE: {CHAVE}
  MYSQL-USER: {CHAVE}
  MYSQL-PASSWORD: {CHAVE}
```

Certifique-se de codificar as chaves em Base64 antes de inseri-las no arquivo.

OBS: Não está sendo enviado no pull request, deverá ser construído para rodar localmente. Instruções estão no README.


---------------------------

## Extra

Utilizei a ferramenta Kompose que faz a conversão do Docker Compose para orquestradores de containers como o Kubernetes e foi sugerido utilizar um PVC para os dados do MySQL. O tipo "PersistentVolumeClaim" (PVC), que é usado para solicitar espaço de armazenamento persistente em um cluster Kubernetes.

```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: mysql-persistencevolumeclaim  # Nome do PersistentVolumeClaim
spec:
  accessModes:
    - ReadWriteOnce  # Modo de acesso: Leitura e escrita por um único nó
  resources:
    requests:
      storage: 100Mi  # Quantidade de armazenamento solicitado
```


